### PR TITLE
Adjust summary card layout

### DIFF
--- a/src/components/salt-calculator.tsx
+++ b/src/components/salt-calculator.tsx
@@ -539,7 +539,7 @@ export default function SaltCalculator() {
                       </div>
                     </div>
                     <div className="text-right">
-                      <div className="flex items-center gap-2 justify-end">
+                      <div className="flex flex-col items-end gap-1">
                         <p className="text-lg font-bold">
                           ${data.totalTax.toLocaleString()}
                         </p>


### PR DESCRIPTION
Display delta values vertically below total tax amounts on summary cards for improved readability.